### PR TITLE
fix: import name - named import

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import NxWelcome from './NxWelcome.vue';
-import Buttons from "buttons";
+import { ButtonsButtons } from "buttons";
 </script>
 
 <template>
-<Buttons></Buttons>
+  <ButtonsButtons></ButtonsButtons>
   <NxWelcome title="vue-test" />
 </template>


### PR DESCRIPTION
The name of your import was inconsistent with the component name [as exported by the library](https://github.com/FrozenPandaz/nx-bugs/blob/vue-standalone-test/buttons/src/index.ts#L1). Also, it should be a named import!